### PR TITLE
Simple template change to silence dozens of identical warnings.

### DIFF
--- a/Templates/Swift/Class.template
+++ b/Templates/Swift/Class.template
@@ -16,6 +16,7 @@ public class {{name}} {% if MessageId != 0 %}: MessagePayload {% endif %}{
     }
 
     public init?(stream:DataInputStream){
+	{% if properties.size > 0 %}
         do{
             {% for property in properties -%}
             {{property.name}} = {{property | reader_method: "stream"}}
@@ -23,6 +24,7 @@ public class {{name}} {% if MessageId != 0 %}: MessagePayload {% endif %}{
         }catch{
             return nil
         }
+	{% endif %}
     }
 
     public func emit(stream:DataOutputStream){


### PR DESCRIPTION
In Swift class's init?(stream:DataInputStream), only generate do/catch blocks if there are any properties in that class, otherwise the Swift compiler will complain that 'catch' block is unreachable because no errors are thrown in 'do’ block